### PR TITLE
Fix pagination of nominations

### DIFF
--- a/librarycard.py
+++ b/librarycard.py
@@ -842,7 +842,7 @@ async def listNominations(ctx, past_sessions: Option(int, "How many prior sessio
     bookCount = 1
 
     for b in itertools.islice(found, page_size):
-      itemList += "\n{}. {}".format(bookCount, pascal_case(str(b['_id'])))
+      itemList += "\n{}. {}".format(bookCount + (p * 10), pascal_case(str(b['_id'])))
       bookCount += 1
       
     embed.add_field(name='Current Nominated Books', value=itemList, inline=False)

--- a/librarycard.py
+++ b/librarycard.py
@@ -1,4 +1,5 @@
 import discord
+import itertools
 import lib.goodreads as goodreads
 import lib.royalroad as royalroad
 import os
@@ -830,7 +831,8 @@ async def listNominations(ctx, past_sessions: Option(int, "How many prior sessio
 
   found = nominateSessions.aggregate(search)
 
-  pagecount = math.ceil((count/10))
+  page_size = 10
+  pagecount = math.ceil((count/page_size))
 
   pages = []
 
@@ -839,7 +841,7 @@ async def listNominations(ctx, past_sessions: Option(int, "How many prior sessio
     itemList = ""
     bookCount = 1
 
-    for b in found:
+    for b in itertools.islice(found, page_size):
       itemList += "\n{}. {}".format(bookCount, pascal_case(str(b['_id'])))
       bookCount += 1
       


### PR DESCRIPTION
Previously, all nominations were displayed on the first page, with blank pages following. This change introduces an islice for the iterable that should match the expected pagination strategy.

It should be noted that Py3.12 introduces itertools.batched, which approximates this; however, this commit does not presume to change Py3.12 to the minimum necessary version.

Fixes #8.