### PR TITLE
Remove "smart punctuation"

### DIFF
--- a/librarycard.py
+++ b/librarycard.py
@@ -833,16 +833,16 @@ async def listNominations(ctx, past_sessions: Option(int, "How many prior sessio
 
   page_size = 10
   pagecount = math.ceil((count/page_size))
+  bookCount = 1
 
   pages = []
 
   for p in range(pagecount):
     embed = discord.Embed(title="Book Nomination", description= str(count) + " books currently nominated" )
     itemList = ""
-    bookCount = 1
 
     for b in itertools.islice(found, page_size):
-      itemList += "\n{}. {}".format(bookCount + (p * 10), pascal_case(str(b['_id'])))
+      itemList += "\n{}. {}".format(bookCount, pascal_case(str(b['_id'])))
       bookCount += 1
       
     embed.add_field(name='Current Nominated Books', value=itemList, inline=False)


### PR DESCRIPTION
This punctuation is enabled by default on most Apple Mac products[1],
while it is enabled almost nowhere else; the standard QWERTY layout
contains only a single and double quote character that, without explicit
directionality, have been rendered as "straight" quotes. The Unicode
codepoints of the “smart” quotes are not equal, and this permitted users
to doubly nominate a book depending on how their input was edited by an
automatic typography option. The commit fixes this issue.

Note that we prefer to remove the "better" typography rather than
upgrade existing typography to it because it's difficult to guess
intent; the heuristic of "at a word boundary" is sufficient for Apple
Mac devices, it seems, but somewhat arbitrary and not strictly correct.
A user with a sufficient code table or input tool could input any such
symbol at any point anyway, or could edit the text around the resulting
text, enabling the same effect. The goal here was to make it easy for
users who (1) only have access to the QWERTY layout and (2) do not have
an input method which automatically replaces the straight marks with
smart marks to select, edit, and nominate books by title that may have
been submitted by users which do have features (1) and (2).

As another Apple Mac default, em dash (—) is also downconverted to two
hyphens (--). This looks worse, but is easier to enter as above.

(This code was tested with a local bot.)